### PR TITLE
Fix handling of non-integer-seconds watch timeouts.

### DIFF
--- a/ZooKeeper.xs
+++ b/ZooKeeper.xs
@@ -2635,6 +2635,10 @@ zkw_wait(zkwh, ...)
 
         end_timeval.tv_sec += timeout / 1000;
         end_timeval.tv_usec += (timeout % 1000) * 1000;
+        if (end_timeval.tv_usec >= 1000000) {
+            end_timeval.tv_usec -= 1000000;
+            end_timeval.tv_sec++;
+        }
 
         wait_timespec.tv_sec = end_timeval.tv_sec;
         wait_timespec.tv_nsec = end_timeval.tv_usec * 1000;

--- a/t/60_watch.t
+++ b/t/60_watch.t
@@ -223,7 +223,9 @@ SKIP: {
             skip 'no connection to ZooKeeper', 9 unless
                 (defined($ret) and $ret);
 
-            my $watch = $zkh->watch('timeout' => 5000);
+            # value here is deliberately not an integer number of seconds,
+            # to exercise timeout handling
+            my $watch = $zkh->watch('timeout' => 4999);
 
 
             ## wait()


### PR DESCRIPTION
When a watch timeout is specified as something other than a multiple of 1000ms, the fractional seconds are being added to the tv_usec value of the current time without checking if the result is greater than a
second's worth of microseconds.

This caused the timespec value used for the call to pthread_cond_timedwait to have an invalid number of nanoseconds, which meant it would return immediately - putting the waiting thread into an tight loop, and making it almost impossible for the notification to be processed.

The fix here just handles this "overflow" case, and adjusts the watch test to make sure this case is exercised.