### PR TITLE
Zookeeper 3.6.0 compilation

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -50,7 +50,7 @@ if ($?) {
     }
     else {
         ## keep in sync with build/check_zk_version.h
-        die("Net::ZooKeeper requires at least ZooKeeper version 3.2.0\n");
+        die("Net::ZooKeeper requires at least ZooKeeper version 3.2.0: $check_out\n");
     }
 }
 

--- a/ZooKeeper.xs
+++ b/ZooKeeper.xs
@@ -28,6 +28,7 @@
 #include <limits.h>                     /* CHAR_BIT */
 #include <sys/time.h>                   /* gettimeofday() */
 
+#define THREADED
 #include <zookeeper/zookeeper.h>
 
 #include "build/check_zk_version.h"

--- a/build/check_zk_version.c
+++ b/build/check_zk_version.c
@@ -23,7 +23,11 @@
 #include "check_zk_version.h"
 
 int main() {
+#ifdef ZOO_VERSION
+  printf("%s\n", ZOO_VERSION);
+#else
   printf("%d.%d.%d\n", ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION);
+#endif
   return 0;
 }
 

--- a/build/check_zk_version.h
+++ b/build/check_zk_version.h
@@ -18,8 +18,9 @@
  */
 
 /* keep in sync with Makefile.PL */
-#if !defined(ZOO_MAJOR_VERSION) || ZOO_MAJOR_VERSION != 3 || \
+#if !defined(ZOO_VERSION)
+# if !defined(ZOO_MAJOR_VERSION) || ZOO_MAJOR_VERSION != 3 || \
     !defined(ZOO_MINOR_VERSION) || ZOO_MINOR_VERSION < 2
-#error "Net::ZooKeeper requires at least ZooKeeper version 3.2.0"
+#  error "Net::ZooKeeper requires at least ZooKeeper version 3.2.0"
+# endif
 #endif
-


### PR DESCRIPTION
Two strange regressions:

1. zookeeper no longer provides MAJOR/MINOR/PATCH versions -- they now only provide a version string
2. zookeeper.h only defines `zoo_create`, `zoo_delete`, etc if `THREADED` is defined.