### PR TITLE
DRAFT: Optionally use Alien::libzookeeper to get the zk libraries

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+use strict;
 use 5.008_008;
 
 use Config;
@@ -39,33 +40,76 @@ my $zk_lib_paths = join(' ', map("-L$_", @zk_lib_paths));
 $zk_inc_paths .= ' ' unless ($zk_inc_paths eq '');
 $zk_lib_paths .= ' ' unless ($zk_lib_paths eq '');
 
-my $cc = $Config{'cc'};
+
+my $lddlflags = $Config{'lddlflags'};
+eval {
+    require Alien::libzookeeper;
+    $zk_inc_paths   .= ' ' . Alien::libzookeeper->cflags;
+    my $libs         = Alien::libzookeeper->libs;
+    my $libs_static  = Alien::libzookeeper->libs_static;
+    if ( $libs ne $libs_static ) {
+        # We can statically link against libzookeeper -- this likely means that
+        # we are compiling against a private version built by Alien::libzookeeper.
+        # To link statically, we need to pass arguments to `ld`, not to the C
+        # compiler, and we need to drop the dynamic version:
+        $_ =~ s/-lzookeeper(?:_mt)?\b// for $libs, $libs_static;
+        $lddlflags  .= ' ' . $libs_static;
+    }
+    $zk_lib_paths   .= ' ' . $libs;
+    1;
+} or do {
+    my $e = $@ || '';
+    # ignore errors from Alien::libzookeeper.  nice if it's available,
+    # but not required.
+};
+
+my @errors;
 my $check_file = 'build/check_zk_version';
+foreach my $extra_zk_lib ( '', '-lzookeeper', '-lzookeeper_mt' ) {
+    my $cc = $Config{'cc'};
 
-my $check_out = qx($cc $zk_inc_paths $zk_lib_paths -I. -o $check_file $check_file.c 2>&1);
+    my $check_out = qx($cc $zk_inc_paths $zk_lib_paths $extra_zk_lib -I. -o $check_file $check_file.c 2>&1);
 
-if ($?) {
-    if ($check_out =~ /zookeeper_version\.h/) {
-        die("Could not determine ZooKeeper version:\n\n$check_out");
+    my $compile_status    = $?;
+    my $compile_exit_code = $compile_status >> 8;
+    if ( $compile_exit_code != 0 ) {
+        # It failed -- save the output and status code, we will use them
+        # if all tries fail:
+        if ($check_out =~ /zookeeper_version\.h/) {
+            push @errors, "Could not determine ZooKeeper version:\n\n$check_out";
+        }
+        else {
+            ## keep in sync with build/check_zk_version.h
+            push @errors, "Net::ZooKeeper requires at least ZooKeeper version 3.2.0: $check_out\n";
+        }
+        next;
     }
-    else {
-        ## keep in sync with build/check_zk_version.h
-        die("Net::ZooKeeper requires at least ZooKeeper version 3.2.0: $check_out\n");
+
+    chomp(my $zk_ver = qx($check_file));
+
+    my $exit_code = $? >> 8;
+    if ($exit_code != 0) {
+        push @errors, "Couldn't check zookeeper version: $zk_ver: $exit_code";
     }
+    elsif ($zk_ver !~ $ZOO_REQUIRED_VERSION) {
+        # TODO: should we try other alternatives here?
+        warn "Net::ZooKeeper requires ZooKeeper 3.x, found $zk_ver!";
+    }
+
+    # libzookeeper is usable!  Update $zk_lib_paths if needed, and carry on:
+    $zk_lib_paths .= ' ' . $extra_zk_lib;
+    @errors        = ();
+    last;
 }
 
-chomp(my $zk_ver = qx($check_file));
-
-if ($? >> 8 != 0) {
-  die "Couldn't check zookeeper version: $zk_ver: $r";
-}
-elsif ($zk_ver !~ $ZOO_REQUIRED_VERSION) {
-  warn "Net::ZooKeeper requires ZooKeeper 3.x, found $zk_ver!";
+if ( @errors ) {
+    die join "\n", @errors;
 }
 
 WriteMakefile(
-    'INC'          => "$zk_inc_paths-I.",
-    'LIBS'         => [ "$zk_lib_paths-lzookeeper_mt" ],
+    'INC'          => "$zk_inc_paths -I.",
+    'LIBS'         => $zk_lib_paths,
+    'LDDLFLAGS'    => $lddlflags,
     'NAME'         => 'Net::ZooKeeper',
     'VERSION_FROM' => 'ZooKeeper.pm',
     'clean'        => { 'FILES' => 'build/check_zk_version.o' },
@@ -75,6 +119,12 @@ WriteMakefile(
             test => {
                 requires => {
                     version => '0.77',
+                },
+            },
+            configure => {
+                # optionally use Alien::libzookeeper, but not a hard requirement:
+                recommends => {
+                    'Alien::libzookeeper' => '0.02',
                 },
             },
         },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -50,8 +50,9 @@ my @archive_after;
 my $makemaker_libs = [];
 my $makemaker_inc  = join(' ', map("-I$_", @zk_inc_paths));
 
-my $ccflags   = $Config{'ccflags'} // '';
-my $lddlflags = prepare_lddlflags($Config{'lddlflags'} // '');
+my $ccflags    = $Config{'ccflags'} // '';
+my $cccdlflags = $Config{'cccdlflags'} // ''; # -fPIC
+my $lddlflags  = prepare_lddlflags($Config{'lddlflags'} // '');
 
 $lddlflags .= ' ' . join ' ', @zk_lib_paths;
 
@@ -105,7 +106,7 @@ my $check_file = 'build/check_zk_version';
 foreach my $extra_zk_lib ( '', '-lzookeeper', '-lzookeeper_mt' ) {
     my $cc = $Config{'cc'};
 
-    my $cmd = "$cc $makemaker_inc $lddlflags $extra_zk_lib -I. -o $check_file $check_file.c 2>&1";
+    my $cmd = "$cc $makemaker_inc $lddlflags $cccdlflags $extra_zk_lib -I. -o $check_file $check_file.c 2>&1";
     my $check_out = qx($cmd);
 
     my $compile_status    = $?;
@@ -118,7 +119,7 @@ foreach my $extra_zk_lib ( '', '-lzookeeper', '-lzookeeper_mt' ) {
         }
         else {
             ## keep in sync with build/check_zk_version.h
-            push @errors, "Net::ZooKeeper requires at least ZooKeeper version 3.2.0: $check_out\n";
+            push @errors, "Net::ZooKeeper requires at least ZooKeeper version 3.2.0:\n$cmd\n$check_out\n";
         }
         next;
     }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,41 +59,34 @@ $lddlflags .= ' ' . join ' ', @zk_lib_paths;
 eval {
     require Alien::libzookeeper;
     $makemaker_inc .= ' ' . Alien::libzookeeper->cflags;
-    if ( Alien::libzookeeper->install_type eq 'share' ) {
-        my $makemaker_libs;
-        # We can statically link against libzookeeper -- this likely means that
-        # we are compiling against a private version built by Alien::libzookeeper.
-        my $libs = Alien::libzookeeper->libs_static || Alien::libzookeeper->lib;
-        # cmake/OSX bug: -lz gets transformed into
-        #   -l/abs/path/to/libz.tbd
-        # in systems with Apple's "built-in dynamic linker cache"
-        $libs =~ s<\B-l/></>g;
+    my $libs = Alien::libzookeeper->install_type eq 'share'
+         ? Alien::libzookeeper->libs_static || Alien::libzookeeper->libs
+         : Alien::libzookeeper->libs
+    ;
+    # cmake/OSX bug: -lz gets transformed into
+    #   -l/abs/path/to/libz.tbd
+    # in systems with Apple's "built-in dynamic linker cache"
+    $libs =~ s<\B-l/></>g;
 
-        my $lib_ext = $Config{lib_ext};
-        foreach my $maybe_lib ( shellwords($libs) ) {
-            if ( $maybe_lib =~ m/\B-l(\S+)/ ) {
-                # -lfoo
-                push @$makemaker_libs, $maybe_lib;
-            }
-            elsif ( $maybe_lib =~ m<-L(\S+)> ) {
-                my $lib_dir = $1;
-                # /path/to/libs
-                # add '-Wl,-rpath=$dir'
-                $libs = '-Wl,-rpath,' . $lib_dir . ' ' . $libs;
-            }
-            elsif ( $maybe_lib =~ m<^/.+$lib_ext$> ) {
-                # .a file in pkg-config --libs output -- this needs to come after the -o
-                push @archive_after, $maybe_lib;
-            }
+    my $lib_ext = $Config{lib_ext};
+    foreach my $maybe_lib ( shellwords($libs) ) {
+        if ( $maybe_lib =~ m/\B-l(\S+)/ ) {
+            # -lfoo
+            push @$makemaker_libs, $maybe_lib;
         }
+        elsif ( $maybe_lib =~ m<-L(\S+)> ) {
+            my $lib_dir = $1;
+            # /path/to/libs
+            # add '-Wl,-rpath=$dir'
+            $libs = '-Wl,-rpath,' . $lib_dir . ' ' . $libs;
+        }
+        elsif ( $maybe_lib =~ m<^/.+$lib_ext$> ) {
+            # .a file in pkg-config --libs output -- this needs to come after the -o
+            push @archive_after, $maybe_lib;
+        }
+    }
 
-        $lddlflags .= ' ' . $libs;
-    }
-    else {
-        # Installing against a libzookeeper provided by the OS; just dump the flags
-        # we got and continue:
-        $lddlflags .= ' ' . Alien::libzookeeper->lib;
-    }
+    $lddlflags .= ' ' . $libs;
     1;
 } or do {
     my $e = $@ || '';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,11 +17,23 @@
 # limitations under the License.
 
 use strict;
-use 5.008_008;
+use v5.15;
 
 use Config;
 use ExtUtils::MakeMaker;
+use Text::ParseWords qw(shellwords);
 use Getopt::Long;
+
+sub prepare_lddlflags {
+    my ($lddlflags) = @_;
+    # `-Wl,-z,now` breaks static linking to libmariadbclient.a, and
+    # the perl you get from pacman in ArchLinux has that by default
+    # in lddlflags.
+    $lddlflags =~ s<,-z[,= ]now><>g;
+    $lddlflags =~ s<,--as-needed\b><>g;
+    $lddlflags =~ s<-Wl\s>< >g; # did we remove every linker option?
+    return $lddlflags;
+}
 
 my $ZOO_MAJOR_VERSION = 3;
 my $ZOO_REQUIRED_VERSION = qr{^$ZOO_MAJOR_VERSION\.\d+.\d+$}ismx;
@@ -34,28 +46,53 @@ GetOptions(
     'zookeeper-lib=s' => \@zk_lib_paths
 );
 
-my $zk_inc_paths = join(' ', map("-I$_", @zk_inc_paths));
-my $zk_lib_paths = join(' ', map("-L$_", @zk_lib_paths));
+my @archive_after;
+my $makemaker_libs = [];
+my $makemaker_inc  = join(' ', map("-I$_", @zk_inc_paths));
 
-$zk_inc_paths .= ' ' unless ($zk_inc_paths eq '');
-$zk_lib_paths .= ' ' unless ($zk_lib_paths eq '');
+my $ccflags   = $Config{'ccflags'} // '';
+my $lddlflags = prepare_lddlflags($Config{'lddlflags'} // '');
 
+$lddlflags .= ' ' . join ' ', @zk_lib_paths;
 
-my $lddlflags = $Config{'lddlflags'};
 eval {
     require Alien::libzookeeper;
-    $zk_inc_paths   .= ' ' . Alien::libzookeeper->cflags;
-    my $libs         = Alien::libzookeeper->libs;
-    my $libs_static  = Alien::libzookeeper->libs_static;
-    if ( $libs ne $libs_static ) {
+    $makemaker_inc .= ' ' . Alien::libzookeeper->cflags;
+    if ( Alien::libzookeeper->install_type eq 'share' ) {
+        my $makemaker_libs;
         # We can statically link against libzookeeper -- this likely means that
         # we are compiling against a private version built by Alien::libzookeeper.
-        # To link statically, we need to pass arguments to `ld`, not to the C
-        # compiler, and we need to drop the dynamic version:
-        $_ =~ s/-lzookeeper(?:_mt)?\b// for $libs, $libs_static;
-        $lddlflags  .= ' ' . $libs_static;
+        my $libs = Alien::libzookeeper->libs_static || Alien::libzookeeper->lib;
+        # cmake/OSX bug: -lz gets transformed into
+        #   -l/abs/path/to/libz.tbd
+        # in systems with Apple's "built-in dynamic linker cache"
+        $libs =~ s<\B-l/></>g;
+
+        my $lib_ext = $Config{lib_ext};
+        foreach my $maybe_lib ( shellwords($libs) ) {
+            if ( $maybe_lib =~ m/\B-l(\S+)/ ) {
+                # -lfoo
+                push @$makemaker_libs, $maybe_lib;
+            }
+            elsif ( $maybe_lib =~ m<-L(\S+)> ) {
+                my $lib_dir = $1;
+                # /path/to/libs
+                # add '-Wl,-rpath=$dir'
+                $libs = '-Wl,-rpath,' . $lib_dir . ' ' . $libs;
+            }
+            elsif ( $maybe_lib =~ m<^/.+$lib_ext$> ) {
+                # .a file in pkg-config --libs output -- this needs to come after the -o
+                push @archive_after, $maybe_lib;
+            }
+        }
+
+        $lddlflags .= ' ' . $libs;
     }
-    $zk_lib_paths   .= ' ' . $libs;
+    else {
+        # Installing against a libzookeeper provided by the OS; just dump the flags
+        # we got and continue:
+        $lddlflags .= ' ' . Alien::libzookeeper->lib;
+    }
     1;
 } or do {
     my $e = $@ || '';
@@ -68,7 +105,8 @@ my $check_file = 'build/check_zk_version';
 foreach my $extra_zk_lib ( '', '-lzookeeper', '-lzookeeper_mt' ) {
     my $cc = $Config{'cc'};
 
-    my $check_out = qx($cc $zk_inc_paths $zk_lib_paths $extra_zk_lib -I. -o $check_file $check_file.c 2>&1);
+    my $cmd = "$cc $makemaker_inc $lddlflags $extra_zk_lib -I. -o $check_file $check_file.c 2>&1";
+    my $check_out = qx($cmd);
 
     my $compile_status    = $?;
     my $compile_exit_code = $compile_status >> 8;
@@ -96,8 +134,8 @@ foreach my $extra_zk_lib ( '', '-lzookeeper', '-lzookeeper_mt' ) {
         warn "Net::ZooKeeper requires ZooKeeper 3.x, found $zk_ver!";
     }
 
-    # libzookeeper is usable!  Update $zk_lib_paths if needed, and carry on:
-    $zk_lib_paths .= ' ' . $extra_zk_lib;
+    # libzookeeper is usable!  Update $lddlflags if needed, and carry on:
+    $lddlflags .= ' ' . $extra_zk_lib;
     @errors        = ();
     last;
 }
@@ -107,9 +145,11 @@ if ( @errors ) {
 }
 
 WriteMakefile(
-    'INC'          => "$zk_inc_paths -I.",
-    'LIBS'         => $zk_lib_paths,
+    'INC'          => "$makemaker_inc -I.",
+    'LIBS'         => $makemaker_libs,
     'LDDLFLAGS'    => $lddlflags,
+    'CCFLAGS'      => $ccflags,
+    'PERL_ARCHIVE_AFTER' => join(' ', @archive_after),
     'NAME'         => 'Net::ZooKeeper',
     'VERSION_FROM' => 'ZooKeeper.pm',
     'clean'        => { 'FILES' => 'build/check_zk_version.o' },
@@ -124,7 +164,7 @@ WriteMakefile(
             configure => {
                 # optionally use Alien::libzookeeper, but not a hard requirement:
                 recommends => {
-                    'Alien::libzookeeper' => '0.02',
+                    'Alien::libzookeeper' => '0.03',
                 },
             },
         },

--- a/build/check_zk_version.c
+++ b/build/check_zk_version.c
@@ -18,15 +18,17 @@
  */
 
 #include <stdio.h>
+#include <zookeeper/zookeeper.h>
 #include <zookeeper/zookeeper_version.h>
 
 #include "check_zk_version.h"
 
 int main() {
+  zoo_set_debug_level(0); // will fail if linking wasn't successful
 #ifdef ZOO_VERSION
   puts(ZOO_VERSION);
 #else
-  printf("%d.%d.%d\n", ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION);
+  printf("version = '%d.%d.%d'\n", ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION, ZOK);
 #endif
   return 0;
 }


### PR DESCRIPTION
A short bit ago I pushed `Alien::libzookeeper`: https://metacpan.org/pod/Alien::libzookeeper

That library handles getting a libzookeeper to compile against -- either from pkg-config, from the OS, and if that fails, from source.

This MR patches the `Net::ZooKeeper` Makefile.PL to optionally use `Alien::libzookeeper`; if that's not installed, it does roughly the same thing as it was doing before, although with a minor tweak to also handle linking against `libzookeeper.so` as well as `libzookeeper_mt.so`.

Regarding _mt vs no _mt:  The no _mt version is generated when the C library is built with make, while the _mt version is generated when the library is built with maven.